### PR TITLE
Close existing TCP socket before opening new connection

### DIFF
--- a/lib/logger_graylog_backend/tcp.ex
+++ b/lib/logger_graylog_backend/tcp.ex
@@ -72,7 +72,7 @@ defmodule LoggerGraylogBackend.Tcp do
   @impl :gen_event
   def handle_event(
         {level, gl, {Logger, message, timestamp, metadata}},
-        %{socket: {:connected, _}} = state
+        %{socket: {:connected, socket}} = state
       )
       when node(gl) == node() do
     with true <- should_log?(level, state),
@@ -80,6 +80,7 @@ defmodule LoggerGraylogBackend.Tcp do
       {:ok, state}
     else
       :error ->
+        :gen_tcp.close(socket)
         {:ok, try_connect(%{state | socket: :disconnected})}
 
       _ ->


### PR DESCRIPTION
According to `gen_tcp` [docs](https://erlang.org/doc/man/gen_tcp.html):
```
An background send will detect a 'remote close' and (the inet driver will) mark the socket as 'closed'. No other action is taken.
```
We should close the socket after `remote close` detection.
In our application, we noticed that ports were leaking due to missing `:gen_tcp.close` before opening a new connection.