### PR TITLE
Accept both :warn and :warning log levels to gelf formatter.

### DIFF
--- a/lib/logger_graylog_backend/gelf_formatter.ex
+++ b/lib/logger_graylog_backend/gelf_formatter.ex
@@ -66,7 +66,7 @@ defmodule LoggerGraylogBackend.GelfFormatter do
   @spec format_level(Logger.level()) :: 7 | 6 | 4 | 3
   defp format_level(:debug), do: 7
   defp format_level(:info), do: 6
-  defp format_level(:warn), do: 4
+  defp format_level(level) when level in ~w(warn warning)a, do: 4
   defp format_level(:error), do: 3
 
   @spec format_timestamp(timestamp) :: float

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,8 @@
-%{"backoff": {:hex, :backoff, "1.1.6", "83b72ed2108ba1ee8f7d1c22e0b4a00cfe3593a67dbc792799e8cce9f42f796b", [:rebar3], [], "hexpm"},
-  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
-  "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "jason": {:hex, :jason, "1.0.0", "0f7cfa9bdb23fed721ec05419bcee2b2c21a77e926bce0deda029b5adc716fe2", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
-  "optium": {:hex, :optium, "0.3.0", "605624128be47aad7f54304ceacca3c0c8454cf3edde10d648b4e1aa9dae64d6", [:mix], [], "hexpm"}}
+%{
+  "backoff": {:hex, :backoff, "1.1.6", "83b72ed2108ba1ee8f7d1c22e0b4a00cfe3593a67dbc792799e8cce9f42f796b", [:rebar3], [], "hexpm", "cf0cfff8995fb20562f822e5cc47d8ccf664c5ecdc26a684cbe85c225f9d7c39"},
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm", "6c32a70ed5d452c6650916555b1f96c79af5fc4bf286997f8b15f213de786f73"},
+  "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm", "c57508ddad47dfb8038ca6de1e616e66e9b87313220ac5d9817bc4a4dc2257b9"},
+  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm", "33d7b70d87d45ed899180fb0413fb77c7c48843188516e15747e00fdecf572b6"},
+  "jason": {:hex, :jason, "1.0.0", "0f7cfa9bdb23fed721ec05419bcee2b2c21a77e926bce0deda029b5adc716fe2", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "b96c400e04b7b765c0854c05a4966323e90c0d11fee0483b1567cda079abb205"},
+  "optium": {:hex, :optium, "0.3.0", "605624128be47aad7f54304ceacca3c0c8454cf3edde10d648b4e1aa9dae64d6", [:mix], [], "hexpm", "e0e84d22d348b201ceec93ccb9d26576786ff8d9d473d056b66765c58311003e"},
+}

--- a/test/logger_graylog_backend/gelf_formatter_test.exs
+++ b/test/logger_graylog_backend/gelf_formatter_test.exs
@@ -30,20 +30,22 @@ defmodule LoggerGraylogBackend.GelfFormatterTest do
     end
   end
 
-  describe "format/6" do
-    test "doesn't include timestamp if the option is passed" do
-      {:ok, gelf} =
-        Formatter.format(
-          "host",
-          :warn,
-          "hello",
-          generate_timestamp(),
-          [],
-          include_timestamp: false
-        )
-        |> decode()
+  for level <- ~w(warn warning)a do
+    describe "format/6 level: #{level}" do
+      test "doesn't include timestamp if the option is passed" do
+        {:ok, gelf} =
+          Formatter.format(
+            "host",
+            unquote(level),
+            "hello",
+            generate_timestamp(),
+            [],
+            include_timestamp: false
+          )
+          |> decode()
 
-      refute Map.has_key?(gelf, "timestamp")
+        refute Map.has_key?(gelf, "timestamp")
+      end
     end
   end
 


### PR DESCRIPTION
After upgrading from Erlang 24.2.2 -> 25.2.3 and Elixir 1.12.3 -> 1.14.2 we were welcomed with following crash

```elixir
Elixir.ErlangError Erlang error: {:EXIT, {:function_clause, [{LoggerGraylogBackend.GelfFormatter, :format_level, [:warning], [file: 'lib/logger_graylog_backend/gelf_formatter.ex', line: 67]}, {LoggerGraylogBackend.GelfFormatter, :format, 6, [file: 'lib/logger_graylog_backend/gelf_formatter.ex', line: 39]}, {LoggerGraylogBackend.Tcp, :log, 5, [file: 'lib/logger_graylog_backend/tcp.ex', line: 155]}, {LoggerGraylogBackend.Tcp, :handle_event, 2, [file: 'lib/logger_graylog_backend/tcp.ex', line: 79]}, {:gen_event, :server_update, 4, [file: 'gen_event.erl', line: 802]}, {:gen_event, :server_notify, 4, [file: 'gen_event.erl', line: 784]}, {:gen_event, :handle_msg, 6, [file: 'gen_event.erl', line: 526]}, 
    {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 240]}]}} 
    gen_server.erl:1241 :gen_server.handle_common_reply/8
    proc_lib.erl:240 ### :proc_lib.init_p_do_apply/3
```

This PR attempts to provide compatibility with both `:warn` and `:warning` levels being passed to the backend.
